### PR TITLE
Enable plugins by default also in portable mode

### DIFF
--- a/src/lib/plugins/plugins.cpp
+++ b/src/lib/plugins/plugins.cpp
@@ -84,7 +84,7 @@ void Plugins::loadSettings()
 {
     Settings settings;
     settings.beginGroup("Plugin-Settings");
-    m_pluginsEnabled = settings.value("EnablePlugins", !mApp->isPortable()).toBool();
+    m_pluginsEnabled = settings.value("EnablePlugins", true).toBool();
     m_allowedPlugins = settings.value("AllowedPlugins", QStringList()).toStringList();
     settings.endGroup();
 

--- a/src/lib/preferences/pluginsmanager.cpp
+++ b/src/lib/preferences/pluginsmanager.cpp
@@ -1,6 +1,6 @@
 /* ============================================================
 * QupZilla - Qt web browser
-* Copyright (C) 2010-2017 David Rosca <nowrep@gmail.com>
+* Copyright (C) 2010-2018 David Rosca <nowrep@gmail.com>
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -41,7 +41,7 @@ PluginsManager::PluginsManager(QWidget* parent)
     //Application Extensions
     Settings settings;
     settings.beginGroup("Plugin-Settings");
-    bool appPluginsEnabled = settings.value("EnablePlugins", !mApp->isPortable()).toBool();
+    bool appPluginsEnabled = settings.value("EnablePlugins", true).toBool();
     settings.endGroup();
 
     ui->allowAppPlugins->setChecked(appPluginsEnabled);


### PR DESCRIPTION
AdBlock now needs plugins enabled to be loaded.